### PR TITLE
Change module and target for compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "compilerOptions": {
-        "target": "ES2022",
-        "module": "ES2022",
+        "target": "esnext",
+        "module": "esnext",
         "moduleResolution": "node16",
-        "lib": ["dom", "es2022"],
+        "lib": ["dom", "esnext"],
         "strict": true,
         "declaration": true,
         "emitDeclarationOnly": true,


### PR DESCRIPTION
Hey! We discovered some interesting thing about your library in our project. We have changed `moduleResolution` to `bundler` in our tsconfig and catch errors from ts about module resolving.

```
src/core/worker/aggregation/grid.ts(1,75): error TS2307: Cannot find module '@trufi/utils' or its corresponding type declarations.
src/core/worker/aggregation/hex.ts(1,75): error TS2307: Cannot find module '@trufi/utils' or its corresponding type declarations.
```

As I can judge, it's happens because you deliver your module with tsconfig and legacy `module` property value. I changed it to more modern `esnext` and errors gone.

@Trufi, could you discover a problem. It's strnage, because I don't find any difference in compiled results with current version but it's works for me :)